### PR TITLE
Update dependencies

### DIFF
--- a/config.go
+++ b/config.go
@@ -12,7 +12,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"gopkg.in/yaml.v2"
 
@@ -37,7 +37,7 @@ type Config struct {
 }
 
 func loadConfig(conf *Config, filename string) error {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}

--- a/dnstap_test.go
+++ b/dnstap_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	dnstap "github.com/dnstap/golang-dnstap"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 
 	nmsg "github.com/farsightsec/go-nmsg"
 	"github.com/farsightsec/go-nmsg/nmsg_base"

--- a/dnstap_test.go
+++ b/dnstap_test.go
@@ -27,6 +27,7 @@ func (tc *sliceClient) Close() error                     { return nil }
 func (tc *sliceClient) DialAndHandle(uri string) error   { return nil }
 func (tc *sliceClient) Receive() <-chan *sielink.Payload { return nil }
 func (tc *sliceClient) Subscribe(...uint32)              {}
+func (tc *sliceClient) Ready() <-chan struct{}           { ch := make(chan struct{}); close(ch); return ch }
 
 func (tc *sliceClient) Send(p *sielink.Payload) error {
 	inp := nmsg.NewInput(bytes.NewReader(p.GetData()), len(p.GetData()))
@@ -93,6 +94,7 @@ type chanClient chan *sielink.Payload
 func (cc chanClient) DialAndHandle(uri string) error   { return nil }
 func (cc chanClient) Receive() <-chan *sielink.Payload { return nil }
 func (cc chanClient) Subscribe(...uint32)              {}
+func (cc chanClient) Ready() <-chan struct{}           { ch := make(chan struct{}); close(ch); return ch }
 
 func (cc chanClient) Close() error {
 	close(cc)

--- a/filter.go
+++ b/filter.go
@@ -49,7 +49,7 @@ func (n nameFilter) Lookup(name []byte) bool {
 	return false
 }
 
-func (n *nameFilter) UnmarshalYAML(u func(interface{}) error) error {
+func (n *nameFilter) UnmarshalYAML(u func(any) error) error {
 	var l []string
 	var err error
 

--- a/filter.go
+++ b/filter.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"errors"
-	"github.com/miekg/dns"
 	"strings"
+
+	"github.com/miekg/dns"
 )
 
 type nameFilter map[string]bool

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/farsightsec/dnstap-sensor
 
-go 1.19
+go 1.23.0
+
+toolchain go1.24.6
 
 require (
 	github.com/dnstap/golang-dnstap v0.4.0
@@ -17,8 +19,8 @@ require (
 	github.com/farsightsec/golang-framestream v0.3.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	golang.org/x/crypto v0.1.0 // indirect
-	golang.org/x/net v0.1.0 // indirect
-	golang.org/x/sys v0.1.0 // indirect
+	golang.org/x/crypto v0.41.0 // indirect
+	golang.org/x/net v0.43.0 // indirect
+	golang.org/x/sys v0.35.0 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/dnstap/golang-dnstap v0.4.0
 	github.com/farsightsec/go-config v0.0.0-20190917161310-3eab84970e6b
 	github.com/farsightsec/go-nmsg v0.2.0
-	github.com/farsightsec/sielink v0.1.1
-	github.com/golang/protobuf v1.5.2
+	github.com/farsightsec/sielink v0.1.2-0.20250826154232-83c0ff8f968d
 	github.com/miekg/dns v1.1.31
 	github.com/xeipuuv/gojsonschema v1.2.0
+	google.golang.org/protobuf v1.36.8
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -22,5 +22,4 @@ require (
 	golang.org/x/crypto v0.41.0 // indirect
 	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
-	google.golang.org/protobuf v1.26.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/farsightsec/go-nmsg v0.2.0 h1:etZN8BGTWYtLP6c/GJFi/r5EJjX03xCUJkJY+ct
 github.com/farsightsec/go-nmsg v0.2.0/go.mod h1:TdmoxDLpgooPNM7WfFTpXhHGDpBtO6m2B3D/C00qq30=
 github.com/farsightsec/golang-framestream v0.3.0 h1:/spFQHucTle/ZIPkYqrfshQqPe2VQEzesH243TjIwqA=
 github.com/farsightsec/golang-framestream v0.3.0/go.mod h1:eNde4IQyEiA5br02AouhEHCu3p3UzrCdFR4LuQHklMI=
-github.com/farsightsec/sielink v0.1.1 h1:eRh9/jDTyfF3YksJx5/GvbU3+oXI8JDosswfQemV4dg=
-github.com/farsightsec/sielink v0.1.1/go.mod h1:PtR+AqhrW7ZC7GPJgZUrbGcaYSY4lpa6ZnZ0tcWsE5U=
+github.com/farsightsec/sielink v0.1.2-0.20250826154232-83c0ff8f968d h1:Yv2YwIlAKrQW38nJDeod71ojFLia0Db/DpkKdx8V9Gc=
+github.com/farsightsec/sielink v0.1.2-0.20250826154232-83c0ff8f968d/go.mod h1:Np1B+4PToGZHAALSe+Gemxc8yZaPsiARU3+EYjxzc3U=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -26,9 +26,6 @@ github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrU
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
-github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
-github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -52,8 +49,6 @@ github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
-golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
 golang.org/x/crypto v0.41.0 h1:WKYxWedPGCTVVl5+WHSSrOBT0O8lx32+zxmHxijgXp4=
 golang.org/x/crypto v0.41.0/go.mod h1:pO5AFd7FA68rFak7rOAGVuygIISepHftHnr8dr6+sUc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -68,9 +63,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.1.0 h1:hZ/3BUoy5aId7sCpA/Tc5lt8DkFgdVS2onTpJsZ/fl0=
-golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
-golang.org/x/net v0.42.0/go.mod h1:FF1RA5d3u7nAYA4z2TkclSCKh68eSXtiFwcWQpPXdt8=
 golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
 golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -82,8 +74,6 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
-golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
 golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -112,9 +102,8 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
-google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
-google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.36.8 h1:xHScyCOEuuwZEc6UtSOvPbAT4zRh0xcNRYekJwfqyMc=
+google.golang.org/protobuf v1.36.8/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
+golang.org/x/crypto v0.41.0 h1:WKYxWedPGCTVVl5+WHSSrOBT0O8lx32+zxmHxijgXp4=
+golang.org/x/crypto v0.41.0/go.mod h1:pO5AFd7FA68rFak7rOAGVuygIISepHftHnr8dr6+sUc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -68,6 +70,9 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.1.0 h1:hZ/3BUoy5aId7sCpA/Tc5lt8DkFgdVS2onTpJsZ/fl0=
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
+golang.org/x/net v0.42.0/go.mod h1:FF1RA5d3u7nAYA4z2TkclSCKh68eSXtiFwcWQpPXdt8=
+golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
+golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -79,6 +84,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/input.go
+++ b/input.go
@@ -11,8 +11,8 @@ package main
 import (
 	"log"
 
-	"github.com/dnstap/golang-dnstap"
-	"github.com/golang/protobuf/proto"
+	dnstap "github.com/dnstap/golang-dnstap"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/farsightsec/go-nmsg"
 	"github.com/farsightsec/go-nmsg/nmsg_base"

--- a/main.go
+++ b/main.go
@@ -28,11 +28,11 @@ type Context struct {
 	stats
 }
 
-func traceMsg(ctx *Context, fmt string, args ...any) {
+func traceMsg(ctx *Context, format string, args ...any) {
 	if !ctx.Trace {
 		return
 	}
-	log.Printf(fmt, args...)
+	log.Printf(format, args...)
 }
 
 type statCounter struct {
@@ -149,7 +149,7 @@ func main() {
 
 	ticker := time.NewTicker(ctx.Config.StatsInterval.Duration)
 	go func() {
-		for _ = range ticker.C {
+		for range ticker.C {
 			ctx.stats.Log()
 		}
 	}()

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ type Context struct {
 	stats
 }
 
-func traceMsg(ctx *Context, fmt string, args ...interface{}) {
+func traceMsg(ctx *Context, fmt string, args ...any) {
 	if !ctx.Trace {
 		return
 	}

--- a/validate.go
+++ b/validate.go
@@ -59,20 +59,20 @@ additionalProperties: false
 `)
 var schema *gojsonschema.Schema
 
-// stringifyMap converts a map[interface{}]interface{} as returned from
-// yaml.Unmarshal into a map[string]interface{} usable by the json-schema
+// stringifyMap converts a map[any]any as returned from
+// yaml.Unmarshal into a map[string]any usable by the json-schema
 // library.
-func stringifyMap(in map[interface{}]interface{}) map[string]interface{} {
-	ret := make(map[string]interface{})
+func stringifyMap(in map[any]any) map[string]any {
+	ret := make(map[string]any)
 	for k, v := range in {
 		key, ok := k.(string)
 		if !ok {
 			key = fmt.Sprintf("%s", k)
 		}
 		switch v := v.(type) {
-		case []interface{}:
+		case []any:
 			ret[key] = stringifySlice(v)
-		case map[interface{}]interface{}:
+		case map[any]any:
 			ret[key] = stringifyMap(v)
 		default:
 			ret[key] = v
@@ -81,15 +81,15 @@ func stringifyMap(in map[interface{}]interface{}) map[string]interface{} {
 	return ret
 }
 
-// stringifySlice converts map[interface{}]interface{} elements of
-// the input []interface{} to map[string]interface{} using stringifyMap
-func stringifySlice(in []interface{}) []interface{} {
-	var ret []interface{}
+// stringifySlice converts map[any]any elements of
+// the input []any to map[string]any using stringifyMap
+func stringifySlice(in []any) []any {
+	var ret []any
 	for _, v := range in {
 		switch v := v.(type) {
-		case []interface{}:
+		case []any:
 			ret = append(ret, stringifySlice(v))
-		case map[interface{}]interface{}:
+		case map[any]any:
 			ret = append(ret, stringifyMap(v))
 		default:
 			ret = append(ret, v)
@@ -99,7 +99,7 @@ func stringifySlice(in []interface{}) []interface{} {
 }
 
 func init() {
-	var schemaObject map[interface{}]interface{}
+	var schemaObject map[any]any
 	err := yaml.Unmarshal(schemaYaml, &schemaObject)
 	if err != nil {
 		log.Fatal("init-yaml: ", err)
@@ -124,7 +124,7 @@ func (e errList) Error() string {
 // Validate parses the configuration contents in the supplied buffer and
 // returns nil if it is a valid config, or an appropriate error otherwise.
 func Validate(b []byte) error {
-	var configObject map[interface{}]interface{}
+	var configObject map[any]any
 	err := yaml.Unmarshal(b, &configObject)
 	if err != nil {
 		return err

--- a/writer.go
+++ b/writer.go
@@ -10,7 +10,6 @@ package main
 
 import (
 	"github.com/farsightsec/sielink"
-	"google.golang.org/protobuf/proto"
 )
 
 // A payloadWriter packs up its input in a sielink Payload as an
@@ -29,10 +28,11 @@ type payloadWriter struct {
 
 func newPayloadWriter(ctx *Context) *payloadWriter {
 	wchan := make(chan *sielink.Payload, 1)
+	channel := ctx.Config.Channel
 	res := &payloadWriter{
 		ctx:          ctx,
 		writeChannel: wchan,
-		channel:      proto.Uint32(ctx.Config.Channel),
+		channel:      &channel,
 	}
 	go func() {
 		for p := range wchan {

--- a/writer.go
+++ b/writer.go
@@ -10,7 +10,7 @@ package main
 
 import (
 	"github.com/farsightsec/sielink"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 // A payloadWriter packs up its input in a sielink Payload as an


### PR DESCRIPTION
Update multiple out-of-date dependencies, including replacing the deprecated `github.com/golang/protobuf` with `google.golang.org/protobuf`

Update `github.com/farsightsec/sielink` version to avoid indirect dependency on deprecated protobuf version, and address client API change in tests.


